### PR TITLE
Fix typo, and adjust regex search for "class"

### DIFF
--- a/plugin/vimux-nose-test.vim
+++ b/plugin/vimux-nose-test.vim
@@ -1,6 +1,6 @@
 " Backwards compatibility
 command! RunAllNoseTests :call RunNoseTestBuffer()
-command! RunFocusedNoseTests :call RunNoseTestFocued()
+command! RunFocusedNoseTests :call RunNoseTestFocused()
 
 command! RunNoseTest :call _run_nosetests("")
 command! RunNoseTestBuffer :call RunNoseTestBuffer()
@@ -11,7 +11,7 @@ function! RunNoseTestBuffer()
 endfunction
 
 function! RunNoseTestFocused()
-  let test_class = _nose_test_search("class")
+  let test_class = _nose_test_search("class ")
   let test_name = _nose_test_search("def test_")
 
   if test_class == "" || test_name == ""


### PR DESCRIPTION
Currently, if a `@classmethod` is defined, or a `setUpClass` method,
this search will catch those instead of the class name. This adds a
trailing space to look for the likely class declaration.

It also fixes a typo.
